### PR TITLE
MP Health: Add context name to response

### DIFF
--- a/appserver/microprofile/health/src/main/java/org/glassfish/microprofile/health/GlassFishHealthCheckResponse.java
+++ b/appserver/microprofile/health/src/main/java/org/glassfish/microprofile/health/GlassFishHealthCheckResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.health;
+
+
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class GlassFishHealthCheckResponse extends HealthCheckResponse {
+
+    private Map<String, Object> data;
+
+    public GlassFishHealthCheckResponse(String name, Status status, Optional<Map<String, Object>> data) {
+        super(name, status, null);
+        this.data = data.orElse(null);
+    }
+
+    public GlassFishHealthCheckResponse() {
+        this(null, null, null);
+    }
+
+    public GlassFishHealthCheckResponse addData(String key, Object value) {
+        if (data == null) {
+            data = new HashMap<>();
+        }
+        data.put(key, value);
+        return this;
+    }
+
+    @Override
+    public Optional<Map<String, Object>> getData() {
+        return Optional.ofNullable(data);
+    }
+
+
+
+}

--- a/appserver/microprofile/health/src/main/java/org/glassfish/microprofile/health/GlassFishHealthCheckResponseBuilder.java
+++ b/appserver/microprofile/health/src/main/java/org/glassfish/microprofile/health/GlassFishHealthCheckResponseBuilder.java
@@ -70,6 +70,6 @@ public class GlassFishHealthCheckResponseBuilder extends HealthCheckResponseBuil
 
     @Override
     public HealthCheckResponse build() {
-        return new HealthCheckResponse(name, status, data.isEmpty() ? null : Optional.of(data));
+        return new GlassFishHealthCheckResponse(name, status, data.isEmpty() ? Optional.empty() : Optional.of(data));
     }
 }


### PR DESCRIPTION
Add app name (context name) to the "context" data attribute.

Example of the status report if the same app is deployed under names "app1" and "app2":

```
{"checks":[
{"name":"ServiceReadyHealthCheck","status":"UP","data":{"ready":true,"context":"app2"}},
{"name":"ServiceStartupHealthCheck","status":"UP","data":{"startup":true,"context":"app2"}},
{"name":"ServiceLiveHealthCheck","status":"UP","data":{"context":"app2","live":true}},
{"name":"ServiceReadyHealthCheck","status":"UP","data":{"ready":true,"context":"app1"}},
{"name":"ServiceLiveHealthCheck","status":"DOWN","data":{"context":"app1","live":true}},
{"name":"ServiceStartupHealthCheck","status":"UP","data":{"startup":true,"context":"app1"}}],
"status":"DOWN"}
```